### PR TITLE
More flexible reminders

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -196,7 +196,7 @@ async def forget(ctx, rowId=None):
         return await ctx.send('Please include the id of the reminder to forget.')
 
     try:
-        responseMsg = reminders.unset_reminder(rowId, ctx.message.author.id)
+        responseMsg = reminders.unset_reminder(rowId, ctx.message.author.id, ctx.guild.id)
         await ctx.send(responseMsg)
     except Exception as e:
         log.error(e)

--- a/bot.py
+++ b/bot.py
@@ -143,7 +143,7 @@ async def trungify(ctx):
     help=('Usage: <number> <second(s)|minute(s)|hour(s)|day(s)|week(s)> [message]\n'
           'Will save a reminder and reply in the same channel at the specifid point in the future. '
           'Long-term reminders poll every minute. Adding a message is optional, '
-          'and will be echoed to you in the case that your message gets deleted.')
+          'and will be echoed back to you.')
 )
 async def remind(ctx, *, message=None):
     if not message:

--- a/bot.py
+++ b/bot.py
@@ -169,11 +169,11 @@ async def remind(ctx, *, message=None):
         await ctx.send("Okay, I'll remind you.")
         await asyncio.sleep(remindAfter.total_seconds())
 
+        _msg = f'\n\n"{msg}"' if msg and len(msg) < 1000 else ''
         try:
             replyTo = await ctx.fetch_message(messageId)
-            return await replyTo.reply('Hey, reminding you about this thing.')
+            return await replyTo.reply(f'Hey, reminding you about this thing.{_msg}')
         except discord.NotFound:
-            _msg = f'\n\n"{msg}"' if msg else ''
             return await ctx.send(f'<@!{userId}>, reminding you of a reminder you '
                                   f'set in this channel <t:{secondsAgo}:R>.{_msg}')
 
@@ -222,11 +222,11 @@ async def task_check():
                 log.info(unsetMsg)
             continue
 
+        _msg = f'\n\n"{msg}"' if msg else ''
         try:
             replyTo = await channel.fetch_message(task['MessageId'])
-            await replyTo.reply(f'<@!{userId}>, reminding you of the message you sent here.')
+            await replyTo.reply(f'<@!{userId}>, reminding you of the message you sent here.{_msg}')
         except discord.NotFound:
-            _msg = f'\n\n"{msg}"' if msg else ''
             await channel.send(f'<@!{userId}>, reminding you of a reminder you '
                                f'set in this channel <t:{createdAt}:R>.{_msg}')
 

--- a/config.py
+++ b/config.py
@@ -22,16 +22,36 @@ TRUNGIFY_CACHE = 'trungified.png'
 SQLITE3_DB_NAME = 'sqlite3.db'
 DB_TABLE_REMINDERS_NAME = 'Reminders'
 
-SERVER_ADMIN_IDS = [
-    # Me
-    116698920515534854,
+GLOBAL_ADMIN_IDS = [116698920515534854]
+SERVER_ADMIN_IDS = {
+    # Infinite Nomic
+    515560801394753537: [
+        179409793885143050,
+        199307546895450112,
+        410992730890698757,
+        339046832195764234
+    ],
+    # Agora
+    724077429412331560: [
+        164117897025683456,
+        120700893212573696
+    ],
+    # Diplomacy
+    892773002440241153: [
+        95923810062053376
+    ],
+    # Dice
+    121129460018708480: [
+        116698920515534854,
+        331266664270266370,
+        231237666597896192,
+    ],
+    # Test Server
+    443181366184640513: [
 
-    # Nomic Moderators
-    179409793885143050,
-    199307546895450112,
-    410992730890698757,
-    339046832195764234
-]
+    ]
+}
+
 
 # Cycle specific configurations #
 _phase_two = 'Resolution Phase'

--- a/reminders.py
+++ b/reminders.py
@@ -105,12 +105,16 @@ def parse_remind_message(msg):
         return (None, 'Please enter an integer number of time units.')
 
     timeUnit = parts[1]
-    remindMsg = None if len(parts) < 2 else ' '.join(parts[2:])
-
     span = nomic_time.parse_timespan_by_units(number, timeUnit)
 
     if not span:
         return (None, 'Please specify a time in the form of `<number> <second(s)|minute(s)|hour(s)|day(s)|week(s)>.`')
+
+    remindMsg = None if len(parts) < 2 else ' '.join(parts[2:])
+
+    # Unescape @'s
+    remindMsg = remindMsg.replace('\\@', '@')
+    remindMsg = remindMsg.replace('\\<', '<')
 
     return (span, remindMsg)
 

--- a/reminders.py
+++ b/reminders.py
@@ -2,7 +2,8 @@ from datetime import datetime, timedelta
 import db
 import nomic_time
 from log import log
-from config import PREFIX, SERVER_ADMIN_IDS
+from config import PREFIX
+import utils
 
 
 def set_new_reminder(userId: str,
@@ -55,7 +56,7 @@ def get_reminder(rowId):
             f"> {remindMsg}")
 
 
-def unset_reminder(rowId, requesterId=None, overrideId=False):
+def unset_reminder(rowId, requesterId=None, serverId=None, overrideId=False):
     '''Either requesterId or overrideId must be set.'''
     try:
         # Also accounts for sql injection attempts
@@ -71,7 +72,7 @@ def unset_reminder(rowId, requesterId=None, overrideId=False):
     if reminders[0]['Active'] == 0:
         return f'Reminder {rowId} is old and wasn\'t going to trigger anyway'
 
-    if overrideId or str(requesterId) == reminders[0]['UserId'] or requesterId in SERVER_ADMIN_IDS:
+    if overrideId or str(requesterId) == reminders[0]['UserId'] or utils.is_admin(requesterId, serverId):
         if db.unset_reminder(rowId):
             return f'You will no longer be reminded of reminder number {rowId}.'
         else:

--- a/reminders.py
+++ b/reminders.py
@@ -83,6 +83,19 @@ def unset_reminder(rowId, requesterId=None, overrideId=False):
 def parse_remind_message(msg):
     # Parse the timestamp as <integer> <minutes|hours|days|weeks|months>
     parts = msg.split(' ')
+
+    # The time unit might have a newline after it instead of a space.
+    # i.e ['1', 'second\nThis\nmessage', 'here'] should be ['1', 'second', 'This\message', 'here']
+    if len(parts) > 1 and '\n' in parts[1]:
+        # subparts = ['second', 'This', 'message]
+        subparts = parts[1].split('\n')
+        # 'second', 'This\nmessage'
+        timepart, firstWord = subparts[0], '\n'.join(subparts[1:])
+        # parts = ['1', 'second', 'here']
+        parts[1] = timepart
+        # ['1', 'second', 'This\message', 'here']
+        parts.insert(2, firstWord)
+
     if len(parts) < 2:
         return (None, f'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
 

--- a/reminders.py
+++ b/reminders.py
@@ -100,9 +100,9 @@ def parse_remind_message(msg):
         return (None, f'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
 
     try:
-        number = int(parts[0])
+        number = float(parts[0])
     except ValueError:
-        return (None, 'Please enter an integer number of time units.')
+        return (None, 'Please enter a real number of time units.')
 
     timeUnit = parts[1]
     span = nomic_time.parse_timespan_by_units(number, timeUnit)

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,6 @@
+from config import GLOBAL_ADMIN_IDS, SERVER_ADMIN_IDS
+
+
 def trim_quotes(string):
     # check if the string is surrounded by quotes
     if string[0] == '"' and string[-1] == '"':
@@ -11,3 +14,13 @@ def strip_command(message, command):
         return message
 
     return ' '.join(message.split(' ')[1:])
+
+
+def is_admin(userId, serverId=None):
+    if userId in GLOBAL_ADMIN_IDS:
+        return True
+
+    if not serverId or serverId not in SERVER_ADMIN_IDS:
+        return False
+
+    return userId in SERVER_ADMIN_IDS[serverId]


### PR DESCRIPTION
* Reminders now always echo the content of the original message, this allows more convenient mentioning in the reply message
* Speaking of that, you can now escape @'s in the &remind command, and the but will unescape them when they reply
  Example: `\@everyone` will `@everyone` when the bot replies
* The bot now accepts non-integer time values. "&remind 2.5 days"
* The admin list is now per-server