### PR TITLE
Add timestamp and loose-matching date syntax to &remind

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -140,6 +140,20 @@ async def trungify(ctx):
 
 
 @bot.command(
+    brief='Get unix timestamp for date string.',
+    help=('Literally just runs the given string against the python-dateutil library. '
+          'Can generally be as vague or specific as you want.')
+)
+async def timestamp(ctx, *, message=None):
+    try:
+        timestamp = nomic_time.get_datestring_timestamp(message)
+    except Exception:
+        return await ctx.send('Whoops, I did\'t recognize the date format you sent. Try something else.')
+
+    await ctx.send(f'Here is your timestamp for <t:{timestamp}> your time: `{timestamp}`')
+
+
+@bot.command(
     brief='Have the bot remind you about something in the future',
     help=('Usage: <number> <second(s)|minute(s)|hour(s)|day(s)|week(s)> [message]\n'
           'Will save a reminder and reply in the same channel at the specified point in the future.\n'
@@ -151,6 +165,21 @@ async def trungify(ctx):
 async def remind(ctx, *, message=None):
     if not message:
         return await ctx.send(f'Please see `{config.PREFIX}help remind` for details on how to use this command.')
+
+    # Get Info to set
+    userId = ctx.message.author.id
+    createdAt = ctx.message.created_at
+    messageId = ctx.message.id
+    channelId = ctx.channel.id
+    remindAfter, _msg = reminders.parse_remind_message(message)
+    msg = await filter_escaped_mentions(ctx, _msg)
+
+    return await handle_set_reminder(ctx, userId, createdAt, messageId, channelId, remindAfter, msg)
+
+
+async def remindAt(ctx, *, message=None):
+    if not message:
+        return await ctx.send(f'Please see `{config.PREFIX}help remindAt` for details on how to use this command.')
 
     # Get Info to set
     userId = ctx.message.author.id

--- a/bot.py
+++ b/bot.py
@@ -155,12 +155,19 @@ async def timestamp(ctx, *, message=None):
 
 @bot.command(
     brief='Have the bot remind you about something in the future',
-    help=('Usage: <number> <second(s)|minute(s)|hour(s)|day(s)|week(s)> [message]\n'
+    help=('Usages: <number> <second(s)|minute(s)|hour(s)|day(s)|week(s)> [message]\n'
+          '        <timestamp>, [message]\n'
+          '        <datestring>, [message]\n'
           'Will save a reminder and reply in the same channel at the specified point in the future.\n'
           'Long-term reminders are checked once per minute. Adding a message is optional, '
-          'and will be echoed back to you.\n'
+          'and will be echoed back to you.\n\n'
           'Escape users and roles in the creation message with User#ID and @"Role" respectively.\n'
-          'For example, User#0000 and @"everyone" will be echoed back as @User#0000 and @everyone.')
+          'For example, User#0000 and @"everyone" will be echoed back as @User#0000 and @everyone.\n\n'
+          'Examples:\n'
+          f'\t{config.PREFIX}remind 5 days'
+          f'\t{config.PREFIX}remind december 15th,'
+          f'\t{config.PREFIX}'
+          )
 )
 async def remind(ctx, *, message=None):
     if not message:

--- a/nomic_time.py
+++ b/nomic_time.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import time
 import calendar
+import dateutil.parser
 from config import PHASES_BY_DAY, PHASE_CYCLE, PHASE_START
 
 
@@ -67,3 +68,10 @@ def parse_timespan_by_units(number, unit):
 
 def _midnightify(date):
     return date.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def get_datestring_timestamp(datestring):
+    if datestring is None or datestring == "" or datestring.lower() == 'now':
+        return unix_now()
+
+    return get_timestamp(dateutil.parser.parse(datestring))

--- a/nomic_time.py
+++ b/nomic_time.py
@@ -66,6 +66,10 @@ def parse_timespan_by_units(number, unit):
     return None
 
 
+def get_timespan_from_timestamp(timestamp):
+    return datetime.utcfromtimestamp(timestamp) - utc_now()
+
+
 def _midnightify(date):
     return date.replace(hour=0, minute=0, second=0, microsecond=0)
 

--- a/nomic_time.py
+++ b/nomic_time.py
@@ -87,7 +87,7 @@ def parse_timespan_by_units(number, unit):
 
 
 def get_timespan_from_timestamp(timestamp):
-    return datetime.utcfromtimestamp(timestamp) - utc_now()
+    return datetime.utcfromtimestamp(timestamp).replace(tzinfo=timezone.utc) - utc_now()
 
 
 def _midnightify(date):

--- a/reminders.py
+++ b/reminders.py
@@ -127,12 +127,15 @@ def parse_remind_message(_msg):
             parts.insert(2, firstWord)
 
         if len(parts) < 2:
-            return (None, f'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
+            return (None, ('Incorrect syntax for reminder or I couldn\'t understand your date format. '
+                           'See `{PREFIX}help remind` for more details.'))
 
         try:
             number = float(parts[0])
         except ValueError:
-            return (None, 'Please enter a real number of time units.')
+            return (None, ('Couldn\'t understand your time format. '
+                           'You might have an extra comma in there confusing things. '
+                           f'See `{PREFIX}help remind` for more details.'))
 
         timeUnit = parts[1]
         span = nomic_time.parse_timespan_by_units(number, timeUnit)
@@ -140,7 +143,10 @@ def parse_remind_message(_msg):
         msg = None if len(parts) < 2 else ' '.join(parts[2:])
 
     if not span:
-        return (None, 'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
+        return (None, f'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
+
+    if span.total_seconds() < 1:
+        return (None, 'Please give a time that is in the future (remember to give a timezone if not in UTC).')
 
     return (span, msg)
 

--- a/reminders.py
+++ b/reminders.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+import re
+
 import db
 import nomic_time
 from log import log
@@ -81,39 +83,66 @@ def unset_reminder(rowId, requesterId=None, serverId=None, overrideId=False):
         return 'Only an admin or the person who created a reminder can delete it.'
 
 
-def parse_remind_message(msg):
-    # Parse the timestamp as <integer> <minutes|hours|days|weeks|months>
-    parts = msg.split(' ')
+def parse_remind_message(_msg):
+    msg = _msg
+    span = None
+    timestamp = None
 
-    # The time unit might have a newline after it instead of a space.
-    # i.e ['1', 'second\nThis\nmessage', 'here'] should be ['1', 'second', 'This\message', 'here']
-    if len(parts) > 1 and '\n' in parts[1]:
-        # subparts = ['second', 'This', 'message]
-        subparts = parts[1].split('\n')
-        # 'second', 'This\nmessage'
-        timepart, firstWord = subparts[0], '\n'.join(subparts[1:])
-        # parts = ['1', 'second', 'here']
-        parts[1] = timepart
-        # ['1', 'second', 'This\message', 'here']
-        parts.insert(2, firstWord)
+    # Check if we were just given a timestamp
+    criteria = r'^\s*<?t?:?(\d{10})'
+    if re.match(criteria, _msg):
+        try:
+            timestamp = int(re.match(criteria, _msg).group(1))
+            span = nomic_time.get_timespan_from_timestamp(timestamp)
+            parts = msg.split(' ')
+            msg = ' '.join(parts[1:])
+        except Exception:
+            timestamp = None
 
-    if len(parts) < 2:
-        return (None, f'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
+    # Check if we have an arbitrary date format on our hands
+    if timestamp is None and '|' in _msg:
+        parts = _msg.split('|')
+        datestring, msg = parts[0], '|'.join(parts[1:])
+        try:
+            timestamp = int(nomic_time.get_datestring_timestamp(datestring))
+            span = nomic_time.get_timespan_from_timestamp(timestamp)
+        except Exception:
+            timestamp = None
 
-    try:
-        number = float(parts[0])
-    except ValueError:
-        return (None, 'Please enter a real number of time units.')
+    # If we still don't have a timestamp, parse it by relative time
+    if timestamp is None:
+        # Parse the timestamp as <integer> <minutes|hours|days|weeks|months>
+        parts = msg.split(' ')
 
-    timeUnit = parts[1]
-    span = nomic_time.parse_timespan_by_units(number, timeUnit)
+        # The time unit might have a newline after it instead of a space.
+        # i.e ['1', 'second\nThis\nmessage', 'here'] should be ['1', 'second', 'This\message', 'here']
+        if len(parts) > 1 and '\n' in parts[1]:
+            # subparts = ['second', 'This', 'message]
+            subparts = parts[1].split('\n')
+            # 'second', 'This\nmessage'
+            timepart, firstWord = subparts[0], '\n'.join(subparts[1:])
+            # parts = ['1', 'second', 'here']
+            parts[1] = timepart
+            # ['1', 'second', 'This\message', 'here']
+            parts.insert(2, firstWord)
+
+        if len(parts) < 2:
+            return (None, f'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
+
+        try:
+            number = float(parts[0])
+        except ValueError:
+            return (None, 'Please enter a real number of time units.')
+
+        timeUnit = parts[1]
+        span = nomic_time.parse_timespan_by_units(number, timeUnit)
+
+        msg = None if len(parts) < 2 else ' '.join(parts[2:])
 
     if not span:
         return (None, 'Please specify a time in the form of `<number> <second(s)|minute(s)|hour(s)|day(s)|week(s)>.`')
 
-    remindMsg = None if len(parts) < 2 else ' '.join(parts[2:])
-
-    return (span, remindMsg)
+    return (span, msg)
 
 
 def can_quick_remind(span: timedelta):

--- a/reminders.py
+++ b/reminders.py
@@ -94,15 +94,15 @@ def parse_remind_message(_msg):
         try:
             timestamp = int(re.match(criteria, _msg).group(1))
             span = nomic_time.get_timespan_from_timestamp(timestamp)
-            parts = msg.split(' ')
+            parts = _msg.split(' ')
             msg = ' '.join(parts[1:])
         except Exception:
             timestamp = None
 
     # Check if we have an arbitrary date format on our hands
-    if timestamp is None and '|' in _msg:
-        parts = _msg.split('|')
-        datestring, msg = parts[0], '|'.join(parts[1:])
+    if timestamp is None and ',' in _msg:
+        parts = _msg.split(',')
+        datestring, msg = parts[0], ','.join(parts[1:])
         try:
             timestamp = int(nomic_time.get_datestring_timestamp(datestring))
             span = nomic_time.get_timespan_from_timestamp(timestamp)
@@ -140,7 +140,7 @@ def parse_remind_message(_msg):
         msg = None if len(parts) < 2 else ' '.join(parts[2:])
 
     if not span:
-        return (None, 'Please specify a time in the form of `<number> <second(s)|minute(s)|hour(s)|day(s)|week(s)>.`')
+        return (None, 'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
 
     return (span, msg)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py==1.7.3
 discord==1.7.3
 python-dotenv==0.19.0
 Pillow==8.3.2
+python-dateutil==2.8.2


### PR DESCRIPTION
Allows for commands like

`&remind 1693402342 Do the thing.`
`&remind <t:1693402342> Do the thing.`
`&remind November 11th Do the thing.`
`&remind November 11th, 2:00pm Do the thing.`