### PR TITLE
&forget in direct messages bug

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -59,7 +59,7 @@ async def time(ctx):
     try:
         await ctx.send(nomic_time.get_current_utc_string())
     except Exception as e:
-        log.error(e)
+        log.exception(e)
         await ctx.send(config.GENERIC_ERROR)
 
 
@@ -80,7 +80,7 @@ async def sha(ctx, *, message=None):
         hash = shalib.get_sha_256(filteredMessage)
         await ctx.send(f'The hash for the above message is:\n{hash}')
     except Exception as e:
-        log.error(e)
+        log.exception(e)
         await ctx.send(config.GENERIC_ERROR)
 
 
@@ -144,7 +144,7 @@ async def trungify(ctx):
 
             await ctx.send(file=f)
     except Exception as e:
-        log.error(e)
+        log.exception(e)
         await ctx.send(config.GENERIC_ERROR)
 
 
@@ -168,7 +168,7 @@ async def draw(ctx, number=1, size=1):
         await ctx.send(('Here are your cards!' if number * size > 1 else 'Here is your card!'))
         await ctx.send(utils.draw_random_card_sets(number, size))
     except Exception as e:
-        log.error(e)
+        log.exception(e)
         await ctx.send(config.GENERIC_ERROR)
 
 
@@ -245,7 +245,7 @@ async def handle_set_reminder(ctx, userId, createdAt, messageId, channelId, remi
         log.info(responseMsg.split('\n')[0])
         await ctx.send(responseMsg)
     except Exception as e:
-        log.error(e)
+        log.exception(e)
         await ctx.send(config.GENERIC_ERROR)
 
 
@@ -292,7 +292,7 @@ async def forget(ctx, rowId=None):
         responseMsg = reminders.unset_reminder(rowId, ctx.message.author.id, ctx.guild.id)
         await ctx.send(responseMsg)
     except Exception as e:
-        log.error(e)
+        log.exception(e)
         await ctx.send(config.GENERIC_ERROR)
 
 

--- a/bot.py
+++ b/bot.py
@@ -288,8 +288,10 @@ async def forget(ctx, rowId=None):
     if not rowId:
         return await ctx.send('Please include the id of the reminder to forget.')
 
+    guildId = ctx.guild.id if ctx.guild else None
+
     try:
-        responseMsg = reminders.unset_reminder(rowId, ctx.message.author.id, ctx.guild.id)
+        responseMsg = reminders.unset_reminder(rowId, ctx.message.author.id, guildId)
         await ctx.send(responseMsg)
     except Exception as e:
         log.exception(e)

--- a/reminders.py
+++ b/reminders.py
@@ -43,7 +43,7 @@ def get_reminder(rowId):
         # Also accounts for sql injection attempts
         rowId = int(rowId)
     except ValueError:
-        log.error(f'User gave a bad rowId to delete: "{rowId}"')
+        log.exception(f'User gave a bad rowId to delete: "{rowId}"')
         return 'That is not a valid reminder Id. Please send the integer Id of a reminder that has been made before'
 
     _reminders = db.get_reminders(f'WHERE RowId = {rowId}')
@@ -64,7 +64,7 @@ def unset_reminder(rowId, requesterId=None, serverId=None, overrideId=False):
         # Also accounts for sql injection attempts
         rowId = int(rowId)
     except ValueError:
-        log.error(f'User gave a bad rowId to delete: "{rowId}"')
+        log.exception(f'User gave a bad rowId to delete: "{rowId}"')
         return 'That is not a valid reminder Id. Please send the integer Id of a reminder that has been made before'
 
     reminders = db.get_reminders(f'WHERE rowid = {rowId}')


### PR DESCRIPTION
&forget wasn't working in direct messages because the script couldn't check if the user was an admin in the guild (because DMs aren't guilds).

Also fixed the exception logging bug that was logging useless exceptions.