### PR TITLE
It's the bugfix PR

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cogs/loot.py
+++ b/cogs/loot.py
@@ -43,9 +43,6 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
             await ctx.send(config.GENERIC_ERROR)
 
     async def handle_pool(self, ctx, comm, pool, arg1, arg2, arg3):
-        if pool is None:
-            return await ctx.send('Please specify the name of the pool you wish operate on.')
-
         comm = comm.lower()
         guildId = ctx.guild.id if ctx.guild else 0
         authorId = ctx.message.author.id
@@ -60,6 +57,9 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
                 await ctx.send(loot.info(guildId, pool))
 
         if comm == 'roll':
+            if pool is None:
+                return await ctx.send('Please specify the name of the pool you wish operate on.')
+
             numRolls = arg1
             extraEntry = arg2
             amount = arg3
@@ -93,6 +93,9 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
                 return
 
         if comm == 'create':
+            if pool is None:
+                return await ctx.send('Please specify the name of the pool you wish operate on.')
+
             if len(pool) > 100:
                 return await ctx.send('Please limit pool names to 100 characters.')
 
@@ -105,7 +108,7 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
         if comm == 'add':
             resultDesc = arg1
             amount = arg2
-            
+
             if pool is None:
                 return await ctx.send('Please specify a pool to remove from.')
 
@@ -132,6 +135,9 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
             await ctx.send(loot.add(guildId, pool, resultDesc, amount))
 
         if comm == 'remove':
+            if pool is None:
+                return await ctx.send('Please specify the name of the pool you wish operate on.')
+
             resultDesc = arg1
             amount = arg2
 

--- a/cogs/loot.py
+++ b/cogs/loot.py
@@ -43,6 +43,9 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
             await ctx.send(config.GENERIC_ERROR)
 
     async def handle_pool(self, ctx, comm, pool, arg1, arg2, arg3):
+        if pool is None:
+            return await ctx.send('Please specify the name of the pool you wish operate on.')
+
         comm = comm.lower()
         guildId = ctx.guild.id if ctx.guild else 0
         authorId = ctx.message.author.id
@@ -91,7 +94,7 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
 
         if comm == 'create':
             if len(pool) > 100:
-                return await ctx.send('Please limit pool names to 100 characters')
+                return await ctx.send('Please limit pool names to 100 characters.')
 
             isGlobal = arg1 is not None and arg1.lower() == 'global'
             await ctx.send(loot.create(guildId, authorId, pool, isGlobal))
@@ -102,6 +105,12 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
         if comm == 'add':
             resultDesc = arg1
             amount = arg2
+            
+            if pool is None:
+                return await ctx.send('Please specify a pool to remove from.')
+
+            if resultDesc is None:
+                return await ctx.send('Please specify a result to remove.')
 
             if len(resultDesc) > 1000:
                 return await ctx.send('Pleas limit result descriptions to 1000 characters')
@@ -125,6 +134,12 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
         if comm == 'remove':
             resultDesc = arg1
             amount = arg2
+
+            if pool is None:
+                return await ctx.send('Please specify a pool to remove from.')
+
+            if resultDesc is None:
+                return await ctx.send('Please specify a result to remove.')
 
             if amount is None:
                 amount = 1

--- a/cogs/loot.py
+++ b/cogs/loot.py
@@ -114,7 +114,7 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
             except Exception:
                 return await ctx.send('The last argument in the command should be a positive integer.')
 
-            if amount < 0:
+            if amount < 1:
                 return await ctx.send('Please send a positive integer.')
 
             if amount is not None and int(amount) > 1000:

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -78,6 +78,9 @@ def add(serverId, poolName, entryDesc, amount=1):
 
     # Add a new result to the table
     if matchingResult is None:
+        if amount < 1:
+            return f'Cannot remove from result "{entryDesc}" because it does not exist.'
+
         try:
             db.add_entry(pool.id, entryDesc, amount)
             return f'Successfullly added result to {pool.name}'

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -107,10 +107,10 @@ def add(serverId, poolName, entryDesc, amount=1):
 
 
 def create(serverId, creatorId, poolName, isGlobal=False):
-    if isGlobal and utils.is_admin(creatorId):
+    if isGlobal and utils.is_admin(creatorId, serverId):
         serverId = 0
 
-    if isGlobal and not utils.is_admin(creatorId):
+    if isGlobal and not utils.is_admin(creatorId, serverId):
         return 'You do not have permission to create global pools.'
 
     existing = db.get_pool(serverId, poolName)

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -113,7 +113,7 @@ def create(serverId, creatorId, poolName, isGlobal=False):
     existing = db.get_pool(serverId, poolName)
 
     if existing is not None:
-        return 'Pool with that name already existss.'
+        return 'Pool with that name already exists.'
 
     try:
         db.add_pool(serverId, creatorId, poolName)

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -110,6 +110,9 @@ def create(serverId, creatorId, poolName, isGlobal=False):
     if isGlobal and utils.is_admin(creatorId):
         serverId = 0
 
+    if isGlobal and not utils.is_admin(creatorId):
+        return 'You do not have permission to create global pools.'
+
     existing = db.get_pool(serverId, poolName)
 
     if existing is not None:

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -9,7 +9,9 @@ import core.utils as utils
 def list(serverId=0):
     pools = db.get_all_pools(serverId)
     if pools is not None and len(pools) > 0:
-        return 'Pools available for this server:\n' + '\n'.join([f'\t{pool.name}' for pool in pools])
+        print([pool.id for pool in pools])
+        body = '\n'.join([f'\t{pool.name}\t{"(global)" if pool.server_id == 0 else ""}' for pool in pools])
+        return f'Pools available for this server:\n{body}'
     else:
         return 'There are no pools available on this server.'
 

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -87,7 +87,7 @@ def add(serverId, poolName, entryDesc, amount=1):
 
     # Updating an existing result.
     matchingResult.amount += amount
-    if matchingResult.amount < 0:
+    if matchingResult.amount < 1:
         try:
             db.unset_entry(matchingResult.id)
             return 'Removed result.'

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -83,7 +83,7 @@ def add(serverId, poolName, entryDesc, amount=1):
 
         try:
             db.add_entry(pool.id, entryDesc, amount)
-            return f'Successfullly added result to {pool.name}'
+            return f'Successfully added result to {pool.name}'
         except Exception:
             log.info(f'Failed to add result `{entryDesc}` to pool {pool.name}')
             return 'Whoops, something went wrong trying to add this result.'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ discord==1.7.3
 python-dotenv==0.19.0
 Pillow==8.3.2
 python-dateutil==2.8.2
+requests==2.26.0


### PR DESCRIPTION
Fixed the following bugs:
✅ Removing the exact amount for result in a pool drops it to 0, but does not remove it from the pool
✅ Can add 0 of a result to a pool
✅ Can remove results from a pool that don't exist
✅ Typo in error "Pool with that name already existss."
✅ "&pool remove " sends the wrong error message
✅ Attempting to create a global pool as a non-admin creates a local pool instead
✅ Typo in "Successfullly added result to "
✅ Server admins are unable to delete global pools (as they should)

Also prettied up the list of pools, adding a (global) indicator to the list.
Also added a LICENSE finally