### PR TITLE
Adjust formatting and organization for &time in Cycle 12

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -54,7 +54,7 @@ def init():
     pools_db.set_tables()
 
     # Load cogs
-    cogs = ['cogs.image_manipulation', 'cogs.reminders', 'cogs.miscellaneous', 'cogs.loot']
+    cogs = ['cogs.cycle', 'cogs.image_manipulation', 'cogs.reminders', 'cogs.miscellaneous', 'cogs.loot']
 
     for cog in cogs:
         try:

--- a/cogs/cycle.py
+++ b/cogs/cycle.py
@@ -1,0 +1,31 @@
+import discord
+from discord.ext import commands
+
+from core.log import log
+import core.nomic_time as nomic_time
+import config.config as config
+
+
+class Cycle(commands.Cog, name='Current Cycle'):
+    '''
+    Commands related to the current Cycle of Infinite Nomic.
+    '''
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(
+        brief='Get information about the current relevant Cycle time',
+        help=('Get current time and day in UTC, as well asn any relevant '
+              'cycle information')
+    )
+    async def time(self, ctx):
+        try:
+            await ctx.send(nomic_time.get_current_utc_string())
+        except Exception as e:
+            log.exception(e)
+            await ctx.send(config.GENERIC_ERROR)
+
+
+def setup(bot):
+    bot.add_cog(Cycle(bot))

--- a/cogs/cycle.py
+++ b/cogs/cycle.py
@@ -15,9 +15,9 @@ class Cycle(commands.Cog, name='Current Cycle'):
         self.bot = bot
 
     @commands.command(
-        brief='Get information about the current relevant Cycle time',
+        brief='Get information about the time relevant to the current Cycle',
         help=('Get current time and day in UTC, as well asn any relevant '
-              'cycle information')
+              'information regarding time in the current Cycle')
     )
     async def time(self, ctx):
         try:

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -19,18 +19,6 @@ class Misc(commands.Cog, name='Miscellaneous'):
         self.bot = bot
 
     @commands.command(
-        brief='Get information about the current relevant Cycle time',
-        help=('Get current time and day in UTC, as well asn any relevant '
-              'cycle information')
-    )
-    async def time(self, ctx):
-        try:
-            await ctx.send(nomic_time.get_current_utc_string())
-        except Exception as e:
-            log.exception(e)
-            await ctx.send(config.GENERIC_ERROR)
-
-    @commands.command(
         brief='Gets the SHA256 for a given input',
         help=('Gets the SHA256 hash for a given input. Note that including '
               'discord mentions may produce unexpected results.\n'

--- a/core/nomic_time.py
+++ b/core/nomic_time.py
@@ -43,7 +43,7 @@ def get_current_utc_string():
 
     return (f'It is **{time}** on **{weekday}**, UTC\n'
             f'That means it is **{phase}**\n\n'
-            f'**{nextPhase}** starts on **{nextDay}**, which is roughly {nextDayRelativeTimestampStr}.\n'
+            f'*{nextPhase}* starts on *{nextDay}*, which is roughly {nextDayRelativeTimestampStr}.\n'
             f'That is {nextDayTimestampStr} your time.')
 
 


### PR DESCRIPTION
* Adjust formatting to draw the eye less to the "next phase" part of &time
* Move & time to a new Cycle cog and update the documentation for it