### PR TITLE
Set up UTC time tracking in a voice channel

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,3 @@
-import asyncio
 import discord
 from discord.ext import commands
 

--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -102,7 +102,7 @@ class Reminders(commands.Cog, name='Reminders'):
             log.info(reminders.unset_reminder(rowId, overrideId=True))
 
     @tasks.loop(minutes=10)
-    async def channel_time(self, ctx):
+    async def channel_time(self):
         datestring = nomic_time.get_formatted_date_string()
         log.info(f'Updating channel time to {datestring}')
         channel = await self.bot.fetch_channel(config.UTC_UPDATE_CHANNEL)

--- a/config/config.py
+++ b/config/config.py
@@ -116,6 +116,8 @@ STOP_DOING_DEFAULT_CHANCE = 0.3
 DEFAULT_STOP_DOING_RESPONSE = 'stop doing nomic.png'
 
 # Cycle specific configurations #
+UTC_UPDATE_CHANNEL = 0  # TODO: Replace with correct channel ID
+
 PHASE_START_DATE = (2022, 4, 4)
 
 _phase_one = 'Phase I'

--- a/config/config.py
+++ b/config/config.py
@@ -118,27 +118,30 @@ DEFAULT_STOP_DOING_RESPONSE = 'stop doing nomic.png'
 # Cycle specific configurations #
 UTC_UPDATE_CHANNEL = 0  # TODO: Replace with correct channel ID
 
-PHASE_START_DATE = (2022, 4, 4)
+PHASE_START_DATE = (2022, 10, 15)
 
 _phase_one = 'Phase I'
 _phase_two = 'Phase II'
+_phase_three = 'Phase III'
 
 PHASES_BY_DAY = {
+    'Sunday': _phase_one,
     'Monday': _phase_one,
     'Tuesday': _phase_one,
-    'Wednesday': _phase_one,
+    'Wednesday': _phase_two,
     'Thursday': _phase_two,
-    'Friday': _phase_two,
-    'Saturday': _phase_two,
-    'Sunday': _phase_two
+    'Friday': _phase_three,
+    'Saturday': _phase_three
 }
 
 PHASE_CYCLE = {
+    _phase_three: _phase_two,
     _phase_two: _phase_one,
-    _phase_one: _phase_two
+    _phase_one: _phase_three
 }
 
 PHASE_START = {
-    _phase_two: 'Thursday',
-    _phase_one: 'Monday'
+    _phase_one: 'Sunday',
+    _phase_two: 'Wednesday',
+    _phase_three: 'Thursday'
 }

--- a/config/config.py
+++ b/config/config.py
@@ -116,7 +116,7 @@ STOP_DOING_DEFAULT_CHANCE = 0.3
 DEFAULT_STOP_DOING_RESPONSE = 'stop doing nomic.png'
 
 # Cycle specific configurations #
-UTC_UPDATE_CHANNEL = 0  # TODO: Replace with correct channel ID
+UTC_UPDATE_CHANNEL = 1029079234427244544
 
 PHASE_START_DATE = (2022, 10, 15)
 

--- a/core/nomic_time.py
+++ b/core/nomic_time.py
@@ -5,7 +5,7 @@ import time
 import calendar
 import dateutil.parser
 
-from config.config import PHASES_BY_DAY, _phase_two, PHASE_CYCLE, PHASE_START, PHASE_START_DATE
+from config.config import PHASES_BY_DAY, _phase_two, _phase_three, PHASE_CYCLE, PHASE_START, PHASE_START_DATE
 import core.utils as utils
 
 
@@ -27,7 +27,8 @@ def get_current_utc_string():
 
     # I don't remember why these -1s and +1s work, but they do so... ¯\_(ツ)_/¯
     weeksSinceStart = ((now - phaseCountStart).days // 7)
-    phasesSinceStart = weeksSinceStart * 2 + (1 if _phase == _phase_two else 0)
+    phasesPerWeek = 3
+    phasesSinceStart = weeksSinceStart * phasesPerWeek + (1 if _phase == _phase_two else 2 if _phase == _phase_three else 0)
     phase = 'Phase ' + utils.roman_numeralize(phasesSinceStart)
     nextPhase = 'Phase ' + utils.roman_numeralize(phasesSinceStart + 1)
     nextDay = PHASE_START[_nextPhase]
@@ -44,7 +45,10 @@ def get_current_utc_string():
             break
 
     return (f'It is **{time}** on **{weekday}**, UTC\n'
-            f'Cycle 12 has ended! See you in Cycle 13!')
+            f'That means it is **{phase}**\n\n'
+            f'*{nextPhase}* starts on *{nextDay}*, which is roughly '
+            f'{nextDayRelativeTimestampStr}.\n'
+            f'That is {nextDayTimestampStr} your time.')
 
 
 def get_formatted_date_string(timestamp: int = None) -> str:
@@ -70,7 +74,7 @@ def seconds_to_next_10_minute_increment():
         return 0
 
     next_minute = ((now.minute // 10) + 1)*10
-    return (next_minute * 60) - ((now.minute * 60) + now.second)
+    return (next_minute * 60) - ((now.minute * 60) + now.second) + 1
 
 
 def utc_now():

--- a/core/nomic_time.py
+++ b/core/nomic_time.py
@@ -47,6 +47,32 @@ def get_current_utc_string():
             f'Cycle 12 has ended! See you in Cycle 13!')
 
 
+def get_formatted_date_string(timestamp: int = None) -> str:
+    """
+    Gets a formatted datestring for the given timestamp. Returns the time string
+    for the current time if no timestamp is given.
+
+    :param timestamp: UTC timestamp, defaults to None
+    :return: Formatted datetime string
+    """
+    timestamp = timestamp if timestamp is not None else get_timestamp(utc_now())
+    format = '%a, %b %d %H:%M UTC'
+
+    return datetime.utcfromtimestamp(timestamp).strftime(format)
+
+
+def seconds_to_next_10_minute_increment():
+    """
+    See function name.
+    """
+    now = utc_now()
+    if now.minute % 10 == 0:
+        return 0
+
+    next_minute = ((now.minute // 10) + 1)*10
+    return (next_minute * 60) - ((now.minute * 60) + now.second)
+
+
 def utc_now():
     # for debugging
     # return datetime(month=4, day=18, year=2022, hour=0, minute=59, second=1).replace(tzinfo=timezone.utc)


### PR DESCRIPTION
The discord API allows for the renaming of a channel twice every 10 minutes, so we have this scheduled to update the configured voice channel with the date and time every round 10-minute increment of the hour.

This accounts for part of issue #80.

Note that the apparent work done to &time is unfinished and not operable as expected.