### PR TITLE
Fix two bugs in &pool

### DIFF
--- a/cogs/loot.py
+++ b/cogs/loot.py
@@ -40,9 +40,9 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
               '  pool delete <poolName>\n'
               '    Delete a pool. Can only be deleted by the original author or an admin.\n\n'
 
-              '  pool add <poolName> <"Result"> <amount>\n'
+              '  pool add <poolName> <amount> <"Result">\n'
               '    Add a number of result entries to a given pool.\n\n'
-              '  pool remove <poolName> <"Result"> <amount>\n'
+              '  pool remove <poolName> <amount> <"Result">\n'
               '    Remove entries from a result. Deletes the result if it drops below 0.\n\n'
               '  pool [add/remove] <poolName> <"Result 1"> <amount 1> <"Result 2"> <amount 2> [...]\n'
               '    Multiple entries can be added or removed from a pool at a time.')

--- a/cogs/loot.py
+++ b/cogs/loot.py
@@ -112,7 +112,7 @@ class Loot(commands.Cog, name='Pools/Loot Tables'):
             if len(pool) > 100:
                 return await ctx.send('Please limit pool names to 100 characters.')
 
-            isGlobal = len(args) < 0 and args[0].lower() == 'global'
+            isGlobal = len(args) > 0 and args[0].lower() == 'global'
             await ctx.send(loot.create(guildId, authorId, pool, isGlobal))
 
         if comm == 'delete':


### PR DESCRIPTION
The first bug isn't even a bug, just a documentation error for `&pool create ....`

The second bug involves creating new global channels. Which has come up just often enough to be frustrating.

Fixes #86 and fixes #99