### PR TITLE
Add language.py and move user-interaction strings to an English locale file

### DIFF
--- a/cogs/cycle.py
+++ b/cogs/cycle.py
@@ -28,28 +28,6 @@ class Cycle(commands.Cog, name='Current Cycle'):
             log.exception(e)
             await ctx.send(config.GENERIC_ERROR)
 
-    @commands.command(
-        brief='Calculate photosynthesis length for the plant',
-        help=('Calculate photosynthesis length for the plant and provide the '
-              'forumla that derives that value'),
-        aliases=['psynth']
-    )
-    async def photosynthesis(self, ctx, length=None, leaves=None):
-        try:
-            length = int(length)
-            leaves = int(leaves)
-        except TypeError:
-            return await ctx.send('Please provide an numerical length and '
-                                  'number of leaves')
-        except ValueError:
-            return await ctx.send('Please provide an numerical length and '
-                                  'number of leaves')
-
-        days = ceil(length/sqrt(leaves))
-        await ctx.send(f'With a total length of `{length}` and `{leaves}` '
-                       f'leaves, photosynthesis will last '
-                       f'`ceil({length}/√{leaves}) = {days}` days.')
-
 
 async def setup(bot):
     await bot.add_cog(Cycle(bot))

--- a/cogs/image_manipulation.py
+++ b/cogs/image_manipulation.py
@@ -6,6 +6,10 @@ import config.config as config
 import core.utils as utils
 import core.image as image
 
+import core.language as language
+
+locale = language.Locale('cogs.image_manipulation')
+
 
 class Image_Manipulation(commands.Cog, name='Image Manipulation'):
     '''
@@ -89,7 +93,7 @@ async def _trung_handler(ctx, detrung: bool, updown: bool):
 
     source = await get_image_source()
     if source is None:
-        await ctx.send('Either I don\'t support that image type or you didn\'t send or reply to an image.')
+        await ctx.send(locale.get_string('imageNotSupported'))
         return
 
     try:

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -90,10 +90,11 @@ class Misc(commands.Cog, name='Miscellaneous'):
     async def timestamp(self, ctx, *, message=None):
         try:
             timestamp = nomic_time.get_datestring_timestamp(message)
+            formattedTimestamp = f'<t:{timestamp}>'
         except Exception:
             return await ctx.send(locale.get_string('timestampBadFormat'))
 
-        await ctx.send(locale.get_string('timestampSuccess', timestamp=timestamp))
+        await ctx.send(locale.get_string('timestampSuccess', formattedTimestamp=formattedTimestamp, timestamp=timestamp))
 
 
 async def setup(bot):

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -9,6 +9,11 @@ import core.sha as shalib
 import core.utils as utils
 import core.stopdoing as stopdoing
 
+import core.language as language
+
+locale = language.Locale('cogs.misc')
+globalLocale = language.Locale('global')
+
 
 class Misc(commands.Cog, name='Miscellaneous'):
     '''
@@ -28,16 +33,16 @@ class Misc(commands.Cog, name='Miscellaneous'):
     )
     async def sha(self, ctx, *, message=None):
         if message is None:
-            await ctx.send("Please include the message you would like me to hash.")
+            await ctx.send(locale.get_string('shaInputMissing'))
             return
 
         try:
             filteredMessage = utils.trim_quotes(message)
             hash = shalib.get_sha_256(filteredMessage)
-            await ctx.send(f'The hash for the above message is:\n{hash}')
+            await ctx.send(locale.get_string('shaHashGiven', hash=hash))
         except Exception as e:
             log.exception(e)
-            await ctx.send(config.GENERIC_ERROR)
+            await ctx.send(globalLocale.get_string('genericError'))
 
     @commands.command(brief='Stop doing nomic', help='Stop doing it.', aliases=['stop', 'stahp'])
     async def stopdoingnomic(self, ctx):
@@ -60,19 +65,22 @@ class Misc(commands.Cog, name='Miscellaneous'):
     )
     async def draw(self, ctx, number=1, size=1):
         if number * size < 1:
-            return await ctx.send('Positive integers only please.')
+            return await ctx.send(locale.get_string('cardsNotPositive'))
 
         maxcards = 50
         if number * size > maxcards:
-            return await ctx.send('Sorry, maximum number of cards per draw '
-                                  f'is {maxcards}.')
+            return await ctx.send(locale.get_string('cardTooMany', maxcards=maxcards))
 
         try:
-            await ctx.send(('Here are your cards!' if number * size > 1 else 'Here is your card!'))
+            if number * size > 1:
+                await ctx.send(locale.get_string('cardSuccess'))
+            else:
+                await ctx.send(locale.get_string('cardSuccessPlural'))
+
             await ctx.send(utils.draw_random_card_sets(number, size))
         except Exception as e:
             log.exception(e)
-            await ctx.send(config.GENERIC_ERROR)
+            await ctx.send(globalLocale.get_string('genericError'))
 
     @commands.command(
         brief='Get unix timestamp for date string',
@@ -83,9 +91,9 @@ class Misc(commands.Cog, name='Miscellaneous'):
         try:
             timestamp = nomic_time.get_datestring_timestamp(message)
         except Exception:
-            return await ctx.send('Whoops, I did\'t recognize the date format you sent. Try something else.')
+            return await ctx.send(locale.get_string('timestampBadFormat'))
 
-        await ctx.send(f'Here is your timestamp for <t:{timestamp}> your time: `{timestamp}`')
+        await ctx.send(locale.get_string('timestampSuccess', timestamp=timestamp))
 
 
 async def setup(bot):

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -73,9 +73,9 @@ class Misc(commands.Cog, name='Miscellaneous'):
 
         try:
             if number * size > 1:
-                await ctx.send(locale.get_string('cardSuccess'))
-            else:
                 await ctx.send(locale.get_string('cardSuccessPlural'))
+            else:
+                await ctx.send(locale.get_string('cardSuccess'))
 
             await ctx.send(utils.draw_random_card_sets(number, size))
         except Exception as e:

--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -9,6 +9,11 @@ from core.log import log
 import core.reminders as reminders
 import core.nomic_time as nomic_time
 
+import core.language as language
+
+locale = language.Locale('cogs.reminders')
+globalLocale = language.Locale('global')
+
 
 class Reminders(commands.Cog, name='Reminders'):
     '''
@@ -48,7 +53,7 @@ class Reminders(commands.Cog, name='Reminders'):
     )
     async def remind(self, ctx, *, message=None):
         if not message:
-            return await ctx.send(f'Please see `{config.PREFIX}help remind` for details on how to use this command.')
+            return await ctx.send(locale.get_string('helpMessage', prefix=config.PREFIX))
 
         # Get Info to set
         userId = ctx.message.author.id
@@ -68,7 +73,7 @@ class Reminders(commands.Cog, name='Reminders'):
     )
     async def forget(self, ctx, rowId=None):
         if not rowId:
-            return await ctx.send('Please include the id of the reminder to forget.')
+            return await ctx.send(locale.get_string('forgetIdNotGiven'))
 
         guildId = ctx.guild.id if ctx.guild else None
 
@@ -79,14 +84,15 @@ class Reminders(commands.Cog, name='Reminders'):
             log.exception(e)
             await ctx.send(config.GENERIC_ERROR)
 
+
     @tasks.loop(minutes=1)
     async def check_reminders(self):
         # Get all active tasks
         tasks = reminders.check_for_triggered_reminders()
 
         for task in tasks:
-            userId = task['UserId']
-            createdAt = task['CreatedAt']
+            userAt = f"<@!{task['UserId']}>"
+            createdAt = f"<t:{task['CreatedAt']}:R>"
             msg = task['RemindMsg']
             rowId = task['rowid']
             channelId = task['ChannelId']
@@ -98,13 +104,14 @@ class Reminders(commands.Cog, name='Reminders'):
                     log.info(unsetMsg)
                 continue
 
-            _msg = f'\n\n"{msg}"' if msg else ''
+            _msg = f'"{msg}"' if msg else ''
             try:
                 replyTo = await channel.fetch_message(task['MessageId'])
-                await replyTo.reply(f'<@!{userId}>, reminding you of the message you sent here.{_msg}')
+                await replyTo.reply(locale.get_string('remindFound', userAt=userAt, message=_msg))
+
             except discord.NotFound:
-                await channel.send(f'<@!{userId}>, reminding you of a reminder you '
-                                   f'set in this channel <t:{createdAt}:R>.{_msg}')
+                await replyTo.reply(locale.get_string('remindChannelNotFound',
+                                                      userAt=userAt, createdAt=createdAt, message=_msg))
 
             log.info(reminders.unset_reminder(rowId, overrideId=True))
 
@@ -192,27 +199,33 @@ async def handle_set_reminder(ctx, userId, createdAt, messageId, channelId, remi
         return await ctx.send(msg)
 
     if remindAfter.total_seconds() < 10:
-        return await ctx.send("C'mon, less than 10 seconds is just silly.")
+        return await ctx.send(locale.get_string('remindSetTooShort'))
 
     if reminders.can_quick_remind(remindAfter):
         seconds = remindAfter.total_seconds()
         secondsAgo = nomic_time.get_timestamp(createdAt)
+        
         log.info(f'Performing quick remind in {seconds} seconds')
-        await ctx.send("Okay, I'll remind you.")
+
+        await ctx.send(locale.get_string('remindSetShort'))
         await asyncio.sleep(remindAfter.total_seconds())
 
-        _msg = f'\n\n"{msg}"' if msg and len(msg) < 1000 else ''
+        _msg = f'"{msg}"' if msg and len(msg) < 1000 else ''
         try:
             replyTo = await ctx.fetch_message(messageId)
-            return await replyTo.reply(f'Hey, reminding you about this thing.{_msg}')
+            return await replyTo.reply(locale.set('remindFoundVeryShort', message=_msg))
+        
         except discord.NotFound:
-            return await ctx.send(f'<@!{userId}>, reminding you of a reminder you '
-                                  f'set in this channel <t:{secondsAgo}:R>.{_msg}')
+            userAt = f'<@!{userId}>'
+            createdAt = f'<t:{secondsAgo}:R>'
+            return await ctx.send(locale.get_string('remindChannelNotFound',
+                                                      userAt=userAt, createdAt=createdAt, message=_msg))
 
     try:
         responseMsg = reminders.set_new_reminder(userId, messageId, channelId, createdAt, remindAfter, msg)
         log.info(responseMsg.split('\n')[0])
         await ctx.send(responseMsg)
+        
     except Exception as e:
         log.exception(e)
         await ctx.send(config.GENERIC_ERROR)

--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -213,7 +213,7 @@ async def handle_set_reminder(ctx, userId, createdAt, messageId, channelId, remi
         _msg = f'"{msg}"' if msg and len(msg) < 1000 else ''
         try:
             replyTo = await ctx.fetch_message(messageId)
-            return await replyTo.reply(locale.set('remindFoundVeryShort', message=_msg))
+            return await replyTo.reply(locale.get_string('remindFoundShort', message=_msg))
         
         except discord.NotFound:
             userAt = f'<@!{userId}>'

--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -82,7 +82,7 @@ class Reminders(commands.Cog, name='Reminders'):
             await ctx.send(responseMsg)
         except Exception as e:
             log.exception(e)
-            await ctx.send(config.GENERIC_ERROR)
+            await ctx.send(globalLocale.get_string('genericError'))
 
 
     @tasks.loop(minutes=1)
@@ -225,10 +225,10 @@ async def handle_set_reminder(ctx, userId, createdAt, messageId, channelId, remi
         responseMsg = reminders.set_new_reminder(userId, messageId, channelId, createdAt, remindAfter, msg)
         log.info(responseMsg.split('\n')[0])
         await ctx.send(responseMsg)
-        
+
     except Exception as e:
         log.exception(e)
-        await ctx.send(config.GENERIC_ERROR)
+        await ctx.send(globalLocale.get_string('genericError'))
 
 
 memberConverter = commands.MemberConverter()

--- a/config/config.py
+++ b/config/config.py
@@ -123,7 +123,7 @@ PHASE_UPDATE_CHANNEL = 1029235284195418192 if not DEBUG else 1029220076097896448
 PHASE_END_UPDATE_CHANNEL = 1033465614695673858 if not DEBUG else 1031640532939702363
 
 PHASE_START_DATE = (2022, 12, 23)
-LOOP_NAME = 'Fifth Loop'
+LOOP_VALUE = 'Eighth'
 
 # Defines the cycle in which phases are looped starting with the start date
 # For instance, a cycle of [3, 2, 2] would have a 3-day Phase I, 2-day Phase II, 2-day Phase III, etc.

--- a/core/db/pools_db.py
+++ b/core/db/pools_db.py
@@ -1,3 +1,4 @@
+from typing import List
 from core.db.db_base import Database
 from core.db.models.pool_models import Pool, Entry
 from config.config import SQLITE3_DB_NAME, DB_TABLE_POOLS_NAME, DB_TABLE_POOL_ENTRIES_NAME
@@ -46,7 +47,7 @@ def _create_table_pool_entries():
 
 
 # Repository Methods
-def get_all_pools(serverId):
+def get_all_pools(serverId) -> List[Pool]:
     results = db.get(
         f'''
         SELECT Id, ServerId, CreatorId, Name, Active
@@ -64,7 +65,7 @@ def get_all_pools(serverId):
     return pools
 
 
-def get_pool(serverId, poolName):
+def get_pool(serverId, poolName) -> List[Pool]:
     results = db.get(
         f'''
         SELECT Id, ServerId, CreatorId, Name, Active
@@ -82,7 +83,7 @@ def get_pool(serverId, poolName):
     return pool
 
 
-def get_entries(poolId, parentPool=None):
+def get_entries(poolId, parentPool=None) -> List[Entry]:
     results = db.get(
         f'''
         SELECT Id, ParentPoolId, Description, Amount, Active
@@ -98,7 +99,7 @@ def get_entries(poolId, parentPool=None):
     return entries
 
 
-def add_pool(serverId, creatorId, poolName):
+def add_pool(serverId, creatorId, poolName) -> int:
     return db.modify(
         f'''
         INSERT INTO {DB_TABLE_POOLS_NAME}
@@ -108,7 +109,7 @@ def add_pool(serverId, creatorId, poolName):
     )
 
 
-def add_entry(poolId, description, amount):
+def add_entry(poolId, description, amount) -> int:
     return db.modify(
         f'''
         INSERT INTO {DB_TABLE_POOL_ENTRIES_NAME}
@@ -118,7 +119,7 @@ def add_entry(poolId, description, amount):
     )
 
 
-def update_entry(entryId, amount):
+def update_entry(entryId, amount) -> int:
     return db.modify(
         f'''
         UPDATE {DB_TABLE_POOL_ENTRIES_NAME}
@@ -128,7 +129,7 @@ def update_entry(entryId, amount):
     )
 
 
-def unset_pool(poolId):
+def unset_pool(poolId) -> int:
     return db.modify(
         f'''
         UPDATE {DB_TABLE_POOLS_NAME}
@@ -138,7 +139,7 @@ def unset_pool(poolId):
     )
 
 
-def unset_entry(entryId):
+def unset_entry(entryId) -> int:
     return db.modify(
         f'''
         UPDATE {DB_TABLE_POOL_ENTRIES_NAME}

--- a/core/language.py
+++ b/core/language.py
@@ -1,0 +1,66 @@
+from typing import List
+from os import path
+import json
+
+_langfile_directory = './langs/'
+_langfile_extension = '.json'
+
+class Culture():
+    # TODO: Put default culture in config
+    default_key = 'en-US'
+    current_key = None
+    
+    default_culture = None
+    current_culture = None
+    
+    def __init__(self, base_path) -> None:
+        # Only runs on first init
+        if self.default_culture is None:
+            self.set_culture(self.default_key, True)
+            self.current_culture = self.default_culture
+        
+        self.base_path = base_path
+
+    def set_culture(self, culture_key:str, set_default:bool=False) -> str:
+        # Check if culture file exists
+        filepath = f'{_langfile_directory}{culture_key}{_langfile_extension}'
+        if not path.exists(filepath):
+            return "A file with that culture doesn't exist."
+
+        # Load the file into memory
+        with open(filepath, 'r') as f:
+            if set_default:
+                self.default_culture = json.load(f)
+            else:
+                self.current_culture = json.load(f)
+        
+        # And we're golden I guess
+        self.current_key = culture_key
+
+    def get_string(self, path, default_lang=False):
+        '''Combine base path with args path to find correct string for key'''
+
+        fullkey = f'{self.base_path}.{path}'
+        fullpath = str.split(fullkey, '.')
+
+        # Navigate down the path of the json object
+        try:
+            node = self.default_culture if default_lang else self.current_culture
+            for step in fullpath:
+                node = node[step]
+
+            assert(type(node) is str)
+        
+        # The path is not valid, but may exist in the default lang file
+        except KeyError:
+            if not default_lang:
+                return self.get_string(path, True)
+            
+            raise KeyError(f'Path does not exist in lang file: {fullkey}')
+        
+        # The given key is valid, but leads to a higher level of nesting
+        except AssertionError:
+            raise KeyError(f'Key does not lead to a string: {fullkey}')
+
+        # If the node is validated as a string, then we can return it
+        return node

--- a/core/language.py
+++ b/core/language.py
@@ -5,47 +5,63 @@ import json
 _langfile_directory = './langs/'
 _langfile_extension = '.json'
 
-class Culture():
-    # TODO: Put default culture in config
+class Locale():
+    # TODO: Put default locale in config
     default_key = 'en-US'
     current_key = None
     
-    default_culture = None
-    current_culture = None
+    default_locale = None
+    current_locale = None
     
     def __init__(self, base_path) -> None:
         # Only runs on first init
-        if self.default_culture is None:
-            self.set_culture(self.default_key, True)
-            self.current_culture = self.default_culture
+        if self.default_locale is None:
+            self.set_locale(self.default_key, True)
+            self.current_locale = self.default_locale
         
         self.base_path = base_path
 
-    def set_culture(self, culture_key:str, set_default:bool=False) -> str:
-        # Check if culture file exists
-        filepath = f'{_langfile_directory}{culture_key}{_langfile_extension}'
+    def set_locale(self, locale_key:str, set_default:bool=False) -> str:
+        # Check if locale file exists
+        filepath = f'{_langfile_directory}{locale_key}{_langfile_extension}'
         if not path.exists(filepath):
-            return "A file with that culture doesn't exist."
+            return "A file with that locale doesn't exist."
 
         # Load the file into memory
         with open(filepath, 'r') as f:
             if set_default:
-                self.default_culture = json.load(f)
+                self.default_locale = json.load(f)
             else:
-                self.current_culture = json.load(f)
+                self.current_locale = json.load(f)
         
         # And we're golden I guess
-        self.current_key = culture_key
+        self.current_key = locale_key
 
-    def get_string(self, path, default_lang=False):
-        '''Combine base path with args path to find correct string for key'''
+    def get_string(self, path, default_lang=False, **formatkwargs):
+        """Combine base path with args path to find correct string for key
+
+        :param path:         Dot-delimited json subpath to target string
+        :param default_lang: Whether to use the default language file, defaults
+                              to False.
+
+        :param formatkwargs: The keyword arguments to pass to the .format() that
+                              gets called on the target string. See the target
+                              string in the json for information on what kwargs
+                              to provide
+
+        :raises KeyError:    If the given path does not exist in the json
+        :raises KeyError:    If the given path is not complete, does not
+                              terminate on a string
+
+        :return:             The formatted string in the json at the target path
+        """                
 
         fullkey = f'{self.base_path}.{path}'
         fullpath = str.split(fullkey, '.')
 
         # Navigate down the path of the json object
         try:
-            node = self.default_culture if default_lang else self.current_culture
+            node = self.default_locale if default_lang else self.current_locale
             for step in fullpath:
                 node = node[step]
 
@@ -54,7 +70,7 @@ class Culture():
         # The path is not valid, but may exist in the default lang file
         except KeyError:
             if not default_lang:
-                return self.get_string(path, True)
+                return self.get_string(path, default_lang=True, **formatkwargs)
             
             raise KeyError(f'Path does not exist in lang file: {fullkey}')
         
@@ -63,4 +79,4 @@ class Culture():
             raise KeyError(f'Key does not lead to a string: {fullkey}')
 
         # If the node is validated as a string, then we can return it
-        return node
+        return node.format(**formatkwargs)

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -48,7 +48,7 @@ def roll(serverId, poolName, numRolls=1, extraEntries=None):
     results = [f'* {entry.description}\n' for entry in chosenEntries]
 
     # Initialize the first message in the body
-    body = [locale.get_string('rollHeader')]
+    body = [locale.get_string('rollHeader', poolName=poolName)]
 
     index = 0
     for result in results:
@@ -113,13 +113,13 @@ def add(serverId, poolName, entries, deleteMode=False):
                     except Exception:
                         log.info(f'Failed to remove result {matchingResult.name} '
                                  f'with id {matchingResult.id} from database')
-                        return locale.get_string('resultRemoveFail')
+                        return locale.get_string('resultRemoveFail', entryDescription=entry.description)
 
                 try:
                     db.update_entry(matchingResult.id, matchingResult.amount)
                 except Exception:
                     log.info(f'Failed to update result with id {matchingResult.id} in database')
-                    return locale.get_string('resultRemoveFail')
+                    return locale.get_string('resultRemoveFail', entryDescription=entry.description)
             else:
                 if len(entries) == 1:
                     return locale.get_string('resultRemoveDoesNotExist')
@@ -161,7 +161,7 @@ def delete(poolName, serverId, userId):
 
     try:
         db.unset_pool(pool.id)
-        return locale.get_string('poolDeleteSuccess')
+        return locale.get_string('poolDeleteSuccess', poolName=poolName)
     except Exception:
         log.info(f'Failed to remove pool {pool.name} with id {pool.id} from database')
         return locale.get_string('poolDeleteFail')

--- a/core/loot_tables.py
+++ b/core/loot_tables.py
@@ -7,7 +7,7 @@ import core.utils as utils
 
 import core.language as language
 
-locale = language.Locale("core.lootTables")
+locale = language.Locale("core.loot_tables")
 
 def list(serverId=0):
     pools = db.get_all_pools(serverId)

--- a/core/reminders.py
+++ b/core/reminders.py
@@ -20,7 +20,7 @@ def set_new_reminder(userId: str,
     '''CreatedAt and remindAfter should be a UTC timestamp in seconds'''
 
     _createdAt = nomic_time.get_timestamp(createdAt)
-    _remindAfter = nomic_time.get_timestamp(createdAt + remindAfter)
+    _remindAfter = f'<t:{nomic_time.get_timestamp(createdAt + remindAfter)}>'
 
     rowId = db.add_reminder(userId, messageId, channelId, _createdAt, _remindAfter, remindMsg)
 
@@ -54,7 +54,7 @@ def get_reminder(rowId):
         return locale.get_string('noReminderIdError', rowId=rowId)
 
     reminder = _reminders[0]
-    remindAfter = reminder['RemindAfter']
+    remindAfter = f'<t:{reminder["RemindAfter"]}:R>'
     remindMsg = reminder['RemindMsg']
 
     return locale.get_string('reminderSetLong', remindAfter=remindAfter, remindMsg=remindMsg)

--- a/core/reminders.py
+++ b/core/reminders.py
@@ -9,7 +9,7 @@ import core.utils as utils
 
 import core.language as language
 
-locale = language.Locale("core.reminders")
+locale = language.Locale('core.reminders')
 
 def set_new_reminder(userId: str,
                      messageId: int,

--- a/core/reminders.py
+++ b/core/reminders.py
@@ -7,6 +7,9 @@ from core.log import log
 from config.config import PREFIX
 import core.utils as utils
 
+import core.language as language
+
+get_string = language.Culture("core.reminders").get_string
 
 def set_new_reminder(userId: str,
                      messageId: int,
@@ -22,7 +25,7 @@ def set_new_reminder(userId: str,
     rowId = db.add_reminder(userId, messageId, channelId, _createdAt, _remindAfter, remindMsg)
 
     if rowId:
-        return(f'I\'ll remind you about this at about <t:{_remindAfter}>.\n'
+        return(f'{get_string("timestamped.reminder1")}<t:{_remindAfter}>.\n'
                f'Use `{PREFIX}forget {rowId}` to delete this reminder.\n')
 
     else:

--- a/core/reminders.py
+++ b/core/reminders.py
@@ -9,7 +9,7 @@ import core.utils as utils
 
 import core.language as language
 
-get_string = language.Culture("core.reminders").get_string
+locale = language.Locale("core.reminders")
 
 def set_new_reminder(userId: str,
                      messageId: int,
@@ -25,9 +25,9 @@ def set_new_reminder(userId: str,
     rowId = db.add_reminder(userId, messageId, channelId, _createdAt, _remindAfter, remindMsg)
 
     if rowId:
-        return(f'{get_string("timestamped.reminder1")}<t:{_remindAfter}>.\n'
-               f'Use `{PREFIX}forget {rowId}` to delete this reminder.\n')
-
+        return(locale.get_string('reminderSet',
+                timestamp=_remindAfter, prefix=PREFIX, rowId=rowId))
+                
     else:
         return 'An error occured trying to set this reminder :(. Some kind of reminder database issue.'
 

--- a/core/reminders.py
+++ b/core/reminders.py
@@ -25,11 +25,11 @@ def set_new_reminder(userId: str,
     rowId = db.add_reminder(userId, messageId, channelId, _createdAt, _remindAfter, remindMsg)
 
     if rowId:
-        return(locale.get_string('reminderSet',
+        return(locale.get_string('reminderSetShort',
                 timestamp=_remindAfter, prefix=PREFIX, rowId=rowId))
                 
     else:
-        return 'An error occured trying to set this reminder :(. Some kind of reminder database issue.'
+        return locale.get_string('reminderError')
 
 
 def check_for_triggered_reminders():
@@ -47,18 +47,17 @@ def get_reminder(rowId):
         rowId = int(rowId)
     except ValueError:
         log.exception(f'User gave a bad rowId to delete: "{rowId}"')
-        return 'That is not a valid reminder Id. Please send the integer Id of a reminder that has been made before'
+        return locale.get_string('idInvalidError')
 
     _reminders = db.get_reminders(f'WHERE RowId = {rowId}')
     if len(_reminders) == 0:
-        return f'No reminder found with id {rowId}.'
+        return locale.get_string('noReminderIdError', rowId=rowId)
 
     reminder = _reminders[0]
     remindAfter = reminder['RemindAfter']
     remindMsg = reminder['RemindMsg']
 
-    return (f"Reminder set to trigger <t:{remindAfter}:R>\n"
-            f"> {remindMsg}")
+    return locale.get_string('reminderSetLong', remindAfter=remindAfter, remindMsg=remindMsg)
 
 
 def unset_reminder(rowId, requesterId=None, serverId=None, overrideId=False):
@@ -68,22 +67,22 @@ def unset_reminder(rowId, requesterId=None, serverId=None, overrideId=False):
         rowId = int(rowId)
     except ValueError:
         log.exception(f'User gave a bad rowId to delete: "{rowId}"')
-        return 'That is not a valid reminder Id. Please send the integer Id of a reminder that has been made before'
+        return locale.get_string('idInvalidError')
 
     reminders = db.get_reminders(f'WHERE rowid = {rowId}')
     if len(reminders) == 0:
-        return 'No reminder found with id {rowId}.'
+        return locale.get_string('noReminderIdError', rowId=rowId)
 
     if reminders[0]['Active'] == 0:
-        return f'Reminder {rowId} is old and wasn\'t going to trigger anyway'
+        return locale.get_string('reminderExpired', rowId=rowId)
 
     if overrideId or str(requesterId) == reminders[0]['UserId'] or utils.is_admin(requesterId, serverId):
         if db.unset_reminder(rowId):
-            return f'You will no longer be reminded of reminder number {rowId}.'
+            return locale.get_string('deleteSuccess', rowId=rowId)
         else:
-            return 'An error occured trying to delete this reminder. Oof.'
+            return locale.get_string('deleteError')
     else:
-        return 'Only an admin or the person who created a reminder can delete it.'
+        return locale.get_string('deleteUnauthorized')
 
 
 def parse_remind_message(_msg, createdAt=None):
@@ -130,14 +129,12 @@ def parse_remind_message(_msg, createdAt=None):
             parts.insert(2, firstWord)
 
         if len(parts) < 2:
-            return (None, ('Incorrect syntax for reminder or I couldn\'t understand your date format. '
-                           'See `{PREFIX}help remind` for more details.'))
+            return (None, locale.get_string('incorrectSyntax1', prefix=PREFIX))
 
         try:
             number = float(parts[0])
         except ValueError:
-            return (None, ('Couldn\'t understand your time format or you might have an extra semicolon in there '
-                           f'confusing things. See `{PREFIX}help remind` for more details.'))
+            return (None, locale.get_string('incorrectSyntax2', prefix=PREFIX))
 
         timeUnit = parts[1]
         span = nomic_time.parse_timespan_by_units(number, timeUnit)
@@ -145,10 +142,10 @@ def parse_remind_message(_msg, createdAt=None):
         msg = None if len(parts) < 2 else ' '.join(parts[2:])
 
     if not span:
-        return (None, f'Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.')
+        return (None, locale.get_string('incorrectSyntaxGeneric'))
 
     if span.total_seconds() < 1:
-        return (None, 'Please give a time that is in the future (remember that times are in UTC).')
+        return (None, locale.get_string('attemptedTimeTravelError'))
 
     return (span, msg)
 

--- a/core/stopdoing.py
+++ b/core/stopdoing.py
@@ -9,6 +9,10 @@ import re
 import config.config as config
 from core.log import log
 
+import core.language as language
+
+locale = language.Locale('core.stopdoing')
+
 
 class Option():
     def __init__(self, func: Callable, weight: int, extra_arg: str = None,
@@ -265,14 +269,11 @@ async def amogus3(ctx):
 
 
 async def bossy(ctx):
-    await ctx.send('*"Stop doing nomic", "what time is it?", "trungify this '
-                   'meme", "pool roll some bullshit".*\n\n'
-                   "Don't you all have anything better to do?")
+    await ctx.send(locale.get_string('bossyResponse'))
 
 
 async def downloadupdate(ctx, bot):
-    await ctx.send(f'There is an update for {config.PREFIX}stopdoingnomic, '
-                   'would you like to download it?')
+    await ctx.send(locale.get_string('dlUpdate.start', prefix=config.PREFIX))
 
     yes_list = ['yes', 'ye', 'yeah', 'y']
     no_list = ['no', 'nah', 'nope', 'n']
@@ -286,41 +287,41 @@ async def downloadupdate(ctx, bot):
 
         if response.content in no_list:
             sleep(1)
-            return await ctx.send('well, fine then. be that way I guess...')
+            return await ctx.send(locale.get_string('dlUpdate.badResponse'))
 
         if response.content in yes_list:
-            msg = await ctx.send('Downloading: `[          ]` ')
+            msg = await ctx.send(locale.get_string('dlUpdate.downloading0%'))
             sleep(1)
-            await msg.edit(content='Downloading: `[||        ]` 20%')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading20%'))
             sleep(2.5)
-            await msg.edit(content='Downloading: `[||||      ]` 42%')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading42%'))
             sleep(2.5)
-            await msg.edit(content='Downloading: `[|||||||   ]` 69% (nice)')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading69%'))
             sleep(2.5)
-            await msg.edit(content='Downloading: `[||||||||| ]` 91%')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading91%'))
             sleep(3)
-            await msg.edit(content='Downloading: `[||||||||||]` 96%')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading96%'))
             sleep(4)
-            await msg.edit(content='Downloading: `[||||||||||]` 99%')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading99%1'))
             sleep(1.5)
-            await msg.edit(content='Downloading: `[||||||||||]` 99%.')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading99%2'))
             sleep(1.5)
-            await msg.edit(content='Downloading: `[||||||||||]` 99%..')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading99%3'))
             sleep(1.5)
-            await msg.edit(content='Downloading: `[||||||||||]` 99%...')
+            await msg.edit(content=locale.get_string('dlUpdate.downloading99%4'))
             sleep(3)
             if random() < .9:
-                await msg.edit(content='Downloading: `[||||||||||]` 99%... ERROR')
+                await msg.edit(content=locale.get_string('downloadingError'))
                 sleep(2)
-                await ctx.send('shit.')
+                await ctx.send(locale.get_string('dlExpletive'))
                 sleep(2)
-                await ctx.send("uhh... let's just try that again later")
+                await ctx.send(locale.get_string('tryAgainLater'))
             else:
-                await msg.edit(content='Downloading: `[||||||||||]` 100%')
+                await msg.edit(content=locale.get_string('downloadingSuccess'))
                 sleep(2)
-                await ctx.send('??? O_o')
+                await ctx.send(locale.get_string('shockAndAwe'))
                 sleep(2)
-                await ctx.send('Holy shit it actually worked?? Congrats???')
+                await ctx.send(locale.get_string('actuallyWorkedDisbelief'))
 
     except asyncio.TimeoutError:
-        await ctx.send("Well fine then. Ignore me why don't you...")
+        await ctx.send(locale.get_string('dlUpdate.responseWaitedTooLong'))

--- a/core/stopdoing.py
+++ b/core/stopdoing.py
@@ -311,17 +311,17 @@ async def downloadupdate(ctx, bot):
             await msg.edit(content=locale.get_string('dlUpdate.downloading99%4'))
             sleep(3)
             if random() < .9:
-                await msg.edit(content=locale.get_string('downloadingError'))
+                await msg.edit(content=locale.get_string('dlUpdate.downloadingError'))
                 sleep(2)
-                await ctx.send(locale.get_string('dlExpletive'))
+                await ctx.send(locale.get_string('dlUpdate.dlExpletive'))
                 sleep(2)
-                await ctx.send(locale.get_string('tryAgainLater'))
+                await ctx.send(locale.get_string('dlUpdate.tryAgainLater'))
             else:
-                await msg.edit(content=locale.get_string('downloadingSuccess'))
+                await msg.edit(content=locale.get_string('dlUpdate.downloadingSuccess'))
                 sleep(2)
-                await ctx.send(locale.get_string('shockAndAwe'))
+                await ctx.send(locale.get_string('dlUpdate.shockAndAwe'))
                 sleep(2)
-                await ctx.send(locale.get_string('actuallyWorkedDisbelief'))
+                await ctx.send(locale.get_string('dlUpdate.actuallyWorkedDisbelief'))
 
     except asyncio.TimeoutError:
         await ctx.send(locale.get_string('dlUpdate.responseWaitedTooLong'))

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -1,6 +1,6 @@
 {
     "core": {
-        "lootTables": {
+        "loot_tables": {
             "poolsAvailable": "Pools available in this server:\n{body}",
             "noPoolsAvailable": "There are no pools available in this server.",
             "poolNotFound": "Could not find a pool with that name in this server.",
@@ -19,6 +19,14 @@
             "deleteAccessDenied": "You do not have permission to delete that pool.",
             "poolDeleteSuccess": "{poolName} pool removed.",
             "poolDeleteFail": "Whoops, something went wrong trying to remove the pool named {poolName}."
+        },
+        "nomic_ime": {
+            "timeUtcReportString": "It is **{time}** on **{weekday}**, UTC\nThat means it is **{phase}**\n\n*{nextPhase}* starts on *{nextDay}*, which is roughly {nextDayRelativeTimestampStr}.\nThat is {nextDayTimestampStr} your time.",
+            "phaseName": "Phase {number}",
+            "phaseNameNegative": "Phase {number}, (or is it Phase {numberOneLess}?)",
+            "khronosPhaseString": "{ordinalValue} Loop, {phaseName}",
+            "phaseEndFar": "Phase ends in {hours} hrs",
+            "phaseEndNear": "Phase ends in {minutes} min"
         },
         "reminders": {
             "reminderSetShort": "I'll remind you about this at about <t:{timestamp}>.\nUse `{prefix}forget {rowId}` to delete this reminder.\n",

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -1,0 +1,9 @@
+{
+    "core": {
+        "reminders": {
+            "timestamped": {
+                "reminder1": "I'll remind you about this at about "
+            }
+        }
+    }
+}

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -39,6 +39,15 @@
             "cardSuccessPlural": "Here are your cards!'",
             "timestampBadFormat": "Whoops, I did't recognize the date format you sent. Try something else.",
             "timestampSuccess": "Here is your timestamp for <t:{timestamp}> your time: `{timestamp}`"
+        },
+        "reminders": {
+            "helpMessage": "Please see `{prefix}help remind` for details on how to use this command.",
+            "forgetIdNotGiven": "Please include the id of the reminder to forget.",
+            "remindFound": "{userAt}, reminding you of the message you sent here.\n\n{message}",
+            "remindChannelNotFound": "{userAt}, reminding you of a reminder you set in this channel {createdAt}.\n\n{_msg}",
+            "remindSetTooShort": "C'mon, less than 10 seconds is just silly.",
+            "remindSetVeryShort": "Okay, I'll remind you.",
+            "remindFoundVeryShort": "Hey, reminding you about this thing.\n\n{message}"
         }
     },
     "core": {

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -1,6 +1,35 @@
 {
+    "global": {
+        "genericError": "Ah shit that didn't work.\nJust let ny know they'll fix it."
+    },
     "cogs": {
-        "cycle": {}
+        "cycle": {},
+        "image_manipulation": {
+            "imageNotSupported": "Either I don't support that image type or you didn't send or reply to an image.",
+        },
+        "pool": {
+            "poolCommandNotFound": "Please provide an argument. See {prefix}help pool for details.",
+            "seeHelpForInfo": " See `{prefix}help pool` for more info.",
+            "listTooManyArgs": "The `list` command does not take any additional arguments.",
+            "infoTooManyArgs": "The `info` command only takes a pool name as an argument.",
+            "rollNameNotGiven": "Please specify the name of the pool you wish operate on.",
+            "rollTooManyPulls": "Pulling from pools is limited to 20 pulls.",
+            "createTooManyArgs": "The `create` command only takes a pool name and an optional (global) flag as arguments.",
+            "createPoolNotGiven": "Please specify the name of the pool you wish operate on.",
+            "createNameTooLong": "Please limit pool names to 100 characters.",
+            "deleteTooManyArgs": "The `delete` command only takes a pool name as an argument.",
+            "addPoolNotGiven": "Please specify a pool to add to.",
+            "addResultNotGiven": "Please specify a result to add to this pool",
+            "addAdditionsBadFormat": "Please list additions by amount, then result description.",
+            "addResultTooLong": "Pleas limit result descriptions to 1000 characters",
+            "addTooManyResults": "Adding entries to a result is limited to 1000 entries at a time.",
+            "removePoolNotGiven": "Please specify a pool to remove from.",
+            "removeResultNotGiven": "Please specify a result to remove from this pool",
+            "removeAdditionsBadFormat": "Please list removals by amount, then result description.",
+            "removeTooManyResults": "Removing entries from a result is limited to 1000 entries at a time.",
+            "errorNotIntegers": "The number of rolls and extra entries should be integers.",
+            "errorNotPositive": "The number of rolls and extra entries should be positive integers."
+        }
     },
     "core": {
         "loot_tables": {

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -1,5 +1,25 @@
 {
     "core": {
+        "lootTables": {
+            "poolsAvailable": "Pools available in this server:\n{body}",
+            "noPoolsAvailable": "There are no pools available in this server.",
+            "poolNotFound": "Could not find a pool with that name in this server.",
+            "poolEmpty": "There are no results in this pool to roll on.",
+            "rollHeader": "Result pulling from {poolName}:\n```\n'",
+            "resultAddFail": "Whoops, something went wrong trying to add the following result. Process aborted.\n(entryDescription)",
+            "resultAddSuccess": "Successfully updated result{plural} in {poolName}",
+            "resultRemoveFail": "Whoops, something went wrong trying to remove the following result. Process aborted.\n{entryDescription}",
+            "resultRemoveDoesNotExist": "Could not remove result. Entry does not exist in pool.",
+            "resultRemovedSuccess": "Successfully removed specified results.",
+            "createGlobalAccessDenied": "You do not have permission to create global pools.",
+            "poolAlreadyExists": "Pool with that name already exists.",
+            "poolCreatedSuccess": "Created new pool {poolName}",
+            "poolCreatedFail": "Whoops, something went wrong trying to create that pool.",
+            "poolDeleteNotFound": "Pool named `{poolName}` not found in this server.",
+            "deleteAccessDenied": "You do not have permission to delete that pool.",
+            "poolDeleteSuccess": "{poolName} pool removed.",
+            "poolDeleteFail": "Whoops, something went wrong trying to remove the pool named {poolName}."
+        },
         "reminders": {
             "reminderSetShort": "I'll remind you about this at about <t:{timestamp}>.\nUse `{prefix}forget {rowId}` to delete this reminder.\n",
             "reminderSetLong": "Reminder set to trigger <t:{remindAfter}:R>\n> {remindMsg}",

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -5,7 +5,7 @@
     "cogs": {
         "cycle": {},
         "image_manipulation": {
-            "imageNotSupported": "Either I don't support that image type or you didn't send or reply to an image.",
+            "imageNotSupported": "Either I don't support that image type or you didn't send or reply to an image."
         },
         "pool": {
             "poolCommandNotFound": "Please provide an argument. See {prefix}help pool for details.",
@@ -24,7 +24,7 @@
             "addResultTooLong": "Pleas limit result descriptions to 1000 characters",
             "addTooManyResults": "Adding entries to a result is limited to 1000 entries at a time.",
             "removePoolNotGiven": "Please specify a pool to remove from.",
-            "removeResultNotGiven": "Please specify a result to remove from this pool",
+            "removeResultNotGiven": "Please specify a result to remove from this pool.",
             "removeAdditionsBadFormat": "Please list removals by amount, then result description.",
             "removeTooManyResults": "Removing entries from a result is limited to 1000 entries at a time.",
             "errorNotIntegers": "The number of rolls and extra entries should be integers.",
@@ -35,8 +35,8 @@
             "shaHashGiven": "The hash for the above message is:\n{hash}",
             "cardsNotPositive": "Positive integers only please.",
             "cardTooMany": "Sorry, maximum number of cards per draw is {maxcards}.",
-            "cardSuccess": "Here is your card!'",
-            "cardSuccessPlural": "Here are your cards!'",
+            "cardSuccess": "Here is your card!",
+            "cardSuccessPlural": "Here are your cards!",
             "timestampBadFormat": "Whoops, I did't recognize the date format you sent. Try something else.",
             "timestampSuccess": "Here is your timestamp for {formattedTimestamp} your time: `{timestamp}`"
         },
@@ -46,8 +46,8 @@
             "remindFound": "{userAt}, reminding you of the message you sent here.\n\n{message}",
             "remindChannelNotFound": "{userAt}, reminding you of a reminder you set in this channel {createdAt}.\n\n{message}",
             "remindSetTooShort": "C'mon, less than 10 seconds is just silly.",
-            "remindSetVeryShort": "Okay, I'll remind you.",
-            "remindFoundVeryShort": "Hey, reminding you about this thing.\n\n{message}"
+            "remindSetShort": "Okay, I'll remind you.",
+            "remindFoundShort": "Hey, reminding you about this thing.\n\n{message}"
         }
     },
     "core": {
@@ -71,7 +71,7 @@
             "poolDeleteSuccess": "{poolName} pool removed.",
             "poolDeleteFail": "Whoops, something went wrong trying to remove the pool named {poolName}."
         },
-        "nomic_ime": {
+        "nomic_time": {
             "timeUtcReportString": "It is **{time}** on **{weekday}**, UTC\nThat means it is **{phase}**\n\n*{nextPhase}* starts on *{nextDay}*, which is roughly {nextDayRelativeTimestampStr}.\nThat is {nextDayTimestampStr} your time.",
             "phaseName": "Phase {number}",
             "phaseNameNegative": "Phase {number}, (or is it Phase {numberOneLess}?)",

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -29,6 +29,16 @@
             "removeTooManyResults": "Removing entries from a result is limited to 1000 entries at a time.",
             "errorNotIntegers": "The number of rolls and extra entries should be integers.",
             "errorNotPositive": "The number of rolls and extra entries should be positive integers."
+        },
+        "misc": {
+            "shaInputMissing": "Please include the message you would like me to hash.",
+            "shaHashGiven": "The hash for the above message is:\n{hash}",
+            "cardsNotPositive": "Positive integers only please.",
+            "cardTooMany": "Sorry, maximum number of cards per draw is {maxcards}.",
+            "cardSuccess": "Here is your card!'",
+            "cardSuccessPlural": "Here are your cards!'",
+            "timestampBadFormat": "Whoops, I did't recognize the date format you sent. Try something else.",
+            "timestampSuccess": "Here is your timestamp for <t:{timestamp}> your time: `{timestamp}`"
         }
     },
     "core": {

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -42,6 +42,30 @@
             "incorrectSyntax2": "Couldn't understand your time format or you might have an extra semicolon in there confusing things. See `{PREFIX}help remind` for more details.",
             "incorrectSyntaxGeneric": "Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.",
             "attemptedTimeTravelError": "Please give a time that is in the future (remember that times are in UTC)."
+        },
+        "stopdoing": {
+            "bossyResponse": "*\"Stop doing nomic\", \"what time is it?\", \"trungify this meme\", \"pool roll some bullshit\".*\n\nDon't you all have anything better to do?",
+            "dlUpdate": {
+                "start": "There is an update for {prefix}stopdoingnomic, would you like to download it?",
+                "badResponse": "well, fine then. be that way I guess...",
+                "responseWaitedTooLong": "Well fine then. Ignore me why don't you...",
+                "downloading0%": "Downloading: `[          ]`",
+                "downloading20%": "Downloading: `[||        ]` 20%",
+                "downloading42%": "Downloading: `[||||      ]` 42%",
+                "downloading69%": "Downloading: `[|||||||   ]` 69% (nice)",
+                "downloading91%": "Downloading: `[||||||||| ]` 91%",
+                "downloading96%": "Downloading: `[||||||||||]` 96%",
+                "downloading99%1": "Downloading: `[||||||||||]` 99%",
+                "downloading99%2": "Downloading: `[||||||||||]` 99%.",
+                "downloading99%3": "Downloading: `[||||||||||]` 99%..",
+                "downloading99%4": "Downloading: `[||||||||||]` 99%...",
+                "downloadingError": "Downloading: `[||||||||||]` 99%... ERROR",
+                "dlExpletive": "shit.",
+                "tryAgainLater": "uhh... let's just try that again later",
+                "downloadingSuccess": "Downloading: `[||||||||||]` 100%",
+                "shockAndAwe": "??? O_o",
+                "actuallyWorkedDisbelief": "Holy shit it actually worked?? Congrats???"
+            }
         }
     }
 }

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -1,7 +1,19 @@
 {
     "core": {
         "reminders": {
-            "reminderSet": "I'll remind you about this at about <t:{timestamp}>.\nUse `{prefix}forget {rowId}` to delete this reminder.\n",
+            "reminderSetShort": "I'll remind you about this at about <t:{timestamp}>.\nUse `{prefix}forget {rowId}` to delete this reminder.\n",
+            "reminderSetLong": "Reminder set to trigger <t:{remindAfter}:R>\n> {remindMsg}",
+            "reminderError": "An error occurred trying to  set this reminder :(. Some kind of reminder database issue.",
+            "idInvalidError": "That is not a valid reminder Id. Please send the integer Id of a reminder that has been made before",
+            "noReminderIdError": "No reminder found with id {rowId}.",
+            "reminderExpired": "Reminder {rowId} is old and wasn't going to trigger anyway",
+            "deleteSuccess": "You will no longer be reminded of reminder number {rowId}.",
+            "deleteError": "An error occurred trying to delete this reminder. Oof.",
+            "deleteUnauthorized": "Only an admin or the person who created a reminder can delete it.",
+            "incorrectSyntax1": "Incorrect syntax for reminder or I couldn't understand your date format. See `{prefix}help remind` for more details.",
+            "incorrectSyntax2": "Couldn't understand your time format or you might have an extra semicolon in there confusing things. See `{PREFIX}help remind` for more details.",
+            "incorrectSyntaxGeneric": "Incorrect syntax for reminder. See `{PREFIX}help remind` for more details.",
+            "attemptedTimeTravelError": "Please give a time that is in the future (remember that times are in UTC)."
         }
     }
 }

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -1,9 +1,7 @@
 {
     "core": {
         "reminders": {
-            "timestamped": {
-                "reminder1": "I'll remind you about this at about "
-            }
+            "reminderSet": "I'll remind you about this at about <t:{timestamp}>.\nUse `{prefix}forget {rowId}` to delete this reminder.\n",
         }
     }
 }

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -1,4 +1,7 @@
 {
+    "cogs": {
+        "cycle": {}
+    },
     "core": {
         "loot_tables": {
             "poolsAvailable": "Pools available in this server:\n{body}",

--- a/langs/en-US.json
+++ b/langs/en-US.json
@@ -38,13 +38,13 @@
             "cardSuccess": "Here is your card!'",
             "cardSuccessPlural": "Here are your cards!'",
             "timestampBadFormat": "Whoops, I did't recognize the date format you sent. Try something else.",
-            "timestampSuccess": "Here is your timestamp for <t:{timestamp}> your time: `{timestamp}`"
+            "timestampSuccess": "Here is your timestamp for {formattedTimestamp} your time: `{timestamp}`"
         },
         "reminders": {
             "helpMessage": "Please see `{prefix}help remind` for details on how to use this command.",
             "forgetIdNotGiven": "Please include the id of the reminder to forget.",
             "remindFound": "{userAt}, reminding you of the message you sent here.\n\n{message}",
-            "remindChannelNotFound": "{userAt}, reminding you of a reminder you set in this channel {createdAt}.\n\n{_msg}",
+            "remindChannelNotFound": "{userAt}, reminding you of a reminder you set in this channel {createdAt}.\n\n{message}",
             "remindSetTooShort": "C'mon, less than 10 seconds is just silly.",
             "remindSetVeryShort": "Okay, I'll remind you.",
             "remindFoundVeryShort": "Hey, reminding you about this thing.\n\n{message}"
@@ -80,8 +80,8 @@
             "phaseEndNear": "Phase ends in {minutes} min"
         },
         "reminders": {
-            "reminderSetShort": "I'll remind you about this at about <t:{timestamp}>.\nUse `{prefix}forget {rowId}` to delete this reminder.\n",
-            "reminderSetLong": "Reminder set to trigger <t:{remindAfter}:R>\n> {remindMsg}",
+            "reminderSetShort": "I'll remind you about this at about {timestamp}.\nUse `{prefix}forget {rowId}` to delete this reminder.\n",
+            "reminderSetLong": "Reminder set to trigger {remindAfter}\n> {remindMsg}",
             "reminderError": "An error occurred trying to  set this reminder :(. Some kind of reminder database issue.",
             "idInvalidError": "That is not a valid reminder Id. Please send the integer Id of a reminder that has been made before",
             "noReminderIdError": "No reminder found with id {rowId}.",

--- a/tests/language_tests.py
+++ b/tests/language_tests.py
@@ -1,0 +1,49 @@
+import core.language
+from importlib import reload
+
+def run_tests():
+    reload(core.language)
+    test_get_string()
+    test_get_string_key_error()
+    test_get_string_incomplete_path()
+
+
+def test_get_string():
+    # Arrange
+    culture = core.language.Culture('core.reminders')
+
+    # Act
+    localization = culture.get_string('timestamped.reminder1', True)
+
+    # Assert
+    assert(localization == "I'll remind you about this at about ")
+    print('test_get_string Passed')
+
+
+def test_get_string_key_error():
+    # Arrange
+    culture = core.language.Culture('core.reminders')
+
+    # Act
+    try:
+        localization = culture.get_string('timestamped.reminderNot1', True)
+    
+    # Assert
+    except KeyError as e:
+        assert(str(e) == "'Path does not exist in lang file'")
+
+    print('test_get_string_key_error Passed')
+
+def test_get_string_incomplete_path():
+    # Arrange
+    culture = core.language.Culture('core.reminders')
+
+    # Act
+    try:
+        localization = culture.get_string('timestamped', True)
+
+    # Assert
+    except KeyError as e:
+        assert(str(e) == "'Key does not lead to a string'")
+    
+    print('test_get_string_incomplete_path Passed')


### PR DESCRIPTION
This pull request primarily does 3 things:

1. Implements a language.py which allows us to source strings from a locale file (i.e. `en-US.json`)
2. Moves as many strings that get sent to discord into said locale file. Note: I'm unsure at this time how to include the various help dialog messages in this flow. TBD.
3. Lay some groundwork for switching between available locales (`set_locale()`), a feature currently unused.